### PR TITLE
Merged with Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # srp_energy
 
+_Update this is now part of Home Assistant Core https://github.com/home-assistant/core/releases/tag/2020.12.1_
+
 _Due to [ADR0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md) this integration was removed from [Home Assistant](https://github.com/home-assistant/home-assistant/tree/0.99.0) with version 0.100, and are now republished here._
 
 ⚠️ This integration scrapes a website to get the information!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # srp_energy
 
-_Update this is now part of Home Assistant Core https://github.com/home-assistant/core/releases/tag/2020.12.1_
+_Update this is now part of Home Assistant Core https://www.home-assistant.io/blog/2020/12/13/release-202012/#new-integrations_
 
 _Due to [ADR0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md) this integration was removed from [Home Assistant](https://github.com/home-assistant/home-assistant/tree/0.99.0) with version 0.100, and are now republished here._
 


### PR DESCRIPTION
Srp Energy is now a part of Home Assistant Core. https://www.home-assistant.io/blog/2020/12/13/release-202012/#new-integrations

Please use that version instead of this.